### PR TITLE
[assertion-profile] Add support for user profile on login callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ const init = async () => {
     plugin: require('hapi-saml2'),
     options: {
       getSAMLOptions: (request) => {}, // required. should return options for `passport-saml`
-      login: async (request, identifier) => {}, // required. should return true if user is authenticated and authenticate user based on identifier (Profile.nameID is used)
+      login: async (request, identifier, user) => {}, // required. should return true if user is authenticated and authenticate user based on identifier (Profile.nameID is used)
       logout: async (request) => {}, // required. should logout the user on the app
       apiPrefix: '/saml', // prefix for added routes
       redirectUrlAfterSuccess: '/', // url to redirect to after successful login

--- a/lib/controller/handlers/callback.js
+++ b/lib/controller/handlers/callback.js
@@ -17,23 +17,23 @@ module.exports = {
 
         if (SAMLResponse) {
           const profile = await promisify(saml.validatePostResponse).bind(saml)(request.payload)
-          return profile.nameID
+          return profile
         }
 
         return Boom.notAcceptable('Invalid SAML format')
       },
-      assign: 'userIdentifier'
+      assign: 'user'
     },
     {
       method: async (request, h) => {
         const {
           pre: {
-            userIdentifier,
+            user,
             login
           }
         } = request
 
-        return Boolean(await login(request, userIdentifier))
+        return Boolean(await login(request, user.nameID, user))
       },
       assign: 'isLoginSuccessful'
     }


### PR DESCRIPTION
Add optional support for the user profile as part of the login callback as described by ﻿﻿https://github.com/toriihq/hapi-saml2/issues/4

```js
server.register({
  plugin: HapiSaml2,
  options: {
    login(request, userIdentifier, user) {},
  },
});
```
