### PR TITLE
v5.1.3 - Fix crash on null SAML profile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # hapi-saml2 Changelog
 
+## Version 5.1.3
+- Fix crash in SAML callback when the profile is null (e.g. NoPassive or LogoutResponse). Now redirects to `redirectUrlAfterFailure` instead of throwing a 500.
+
 ## Version 5.1.2
 - Add `files` field to package.json to limit published package to `lib/` only
 

--- a/lib/controller/handlers/callback.js
+++ b/lib/controller/handlers/callback.js
@@ -45,6 +45,10 @@ module.exports = {
           }
         } = request
 
+        if (!user || Boom.isBoom(user)) {
+          return user || false
+        }
+
         const loginResult = await login(request, user.nameID, user)
 
         if (loginResult && loginResult.success === false) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hapi-saml2",
-  "version": "5.1.2",
+  "version": "5.1.3",
   "description": "SAML Auth for Hapi.js",
   "main": "./lib/index.js",
   "files": [

--- a/tests/callback-null-profile.test.js
+++ b/tests/callback-null-profile.test.js
@@ -1,0 +1,55 @@
+const Hapi = require('@hapi/hapi')
+const Boom = require('@hapi/boom')
+
+// Mock @node-saml/node-saml to return { profile: null } — this simulates
+// NoPassive status responses and LogoutResponse messages, which previously
+// crashed the callback handler with "Cannot read properties of null (reading 'nameID')".
+jest.mock('@node-saml/node-saml', () => ({
+  SAML: jest.fn().mockImplementation(() => ({
+    validatePostResponseAsync: jest.fn(async () => ({ profile: null })),
+    getAuthorizeUrlAsync: jest.fn(async () => 'http://localhost:3000/entryPoint?SAMLRequest=x'),
+    getLogoutUrlAsync: jest.fn(async () => 'http://localhost:3000/entryPoint?SAMLRequest=x')
+  }))
+}))
+
+describe('Callback with null profile', () => {
+  let server
+  const loginMock = jest.fn()
+
+  beforeAll(async () => {
+    server = Hapi.server({ port: 0, host: 'localhost' })
+
+    await server.register({
+      plugin: require('hapi-saml2'),
+      options: {
+        login: loginMock,
+        logout: jest.fn(async () => {}),
+        apiPrefix: '/saml-test',
+        redirectUrlAfterSuccess: '/success',
+        redirectUrlAfterFailure: '/failure',
+        boomErrorForMissingConfiguration: Boom.badImplementation('SAML instance is not configured'),
+        boomErrorForIncorrectConfiguration: Boom.badImplementation('SAML configuration is incorrect'),
+        getSAMLOptions: jest.fn(async () => ({
+          callbackUrl: 'http://localhost:3000/callback',
+          issuer: 'https://saml.example.com/',
+          idpCert: 'unused-due-to-mock',
+          entryPoint: 'http://localhost:3000/entryPoint',
+          generateUniqueId: () => 'uniqueId'
+        }))
+      }
+    })
+    await server.initialize()
+  })
+
+  it('should redirect to the failure page without calling login() when profile is null', async () => {
+    const response = await server.inject({
+      method: 'POST',
+      url: '/saml-test/callback',
+      payload: { SAMLResponse: 'any-value-mocked' }
+    })
+
+    expect(response.statusCode).toEqual(302)
+    expect(response.headers.location).toEqual('/failure')
+    expect(loginMock).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary

- Fix a 500 crash in the SAML callback when `@node-saml/node-saml` returns `{ profile: null }` — happens on NoPassive status responses and LogoutResponse messages. Previously threw `Cannot read properties of null (reading 'nameID')`.
- Now short-circuits to `isLoginSuccessful = false`, redirecting the user to `redirectUrlAfterFailure` — the correct behavior for these cases.
- Also guards against Boom error values propagated from the first pre-handler.
- Bumps version to 5.1.3 and adds a changelog entry.

## Test plan

- [x] New regression test `tests/callback-null-profile.test.js` — mocks `@node-saml/node-saml` to return `{ profile: null }`, asserts 302 → `/failure` and that `login()` is not called. Verified test fails without the fix and passes with it.
- [x] All 21 existing tests pass.

## Context

Triggered by a production 500 on `POST /api/saml/{idOrg}/callback` (Datadog monitor 141659452). Complementary fix in toriihq/torii-monorepo#12011 handles a related case (valid profile but non-email NameID) in the `SAML.login` handler — that PR should bump its `hapi-saml2` dep to 5.1.3 to consume this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)